### PR TITLE
Add Matter timer switch example for ESP32-C6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(timer_switch)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Matter Timer Switch for ESP32-C6
+
+This project provides a simple example of a timer controlled GPIO switch implemented using the Matter protocol. The switch supports two modes:
+
+1. **Continuous On/Off** – drive the GPIO high or low without a timer.
+2. **Cycle Mode** – keep the GPIO on for `X` seconds/minutes and then off for `X` seconds/minutes in a loop.
+
+The example uses the ESP‑Matter SDK and targets the ESP32‑C6.
+
+## File Structure
+
+- `CMakeLists.txt` – project definition for ESP‑IDF.
+- `main/timer_switch.c` – application source implementing the timer logic and Matter endpoint.
+
+## Usage
+
+1. Set up [ESP‑IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) and the [ESP‑Matter](https://github.com/espressif/esp-matter) SDK.
+2. Configure the project using `idf.py menuconfig` to select your Wi‑Fi credentials and other parameters.
+3. Build and flash with `idf.py -p PORT flash monitor`.
+
+The `app_main` function in `timer_switch.c` shows an example that cycles the GPIO on for 60 s and off for 30 s. Modify the call to `start_cycle` or use `start_continuous` to change behaviour as needed.
+

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "timer_switch.c"
+                       INCLUDE_DIRS ".")

--- a/main/timer_switch.c
+++ b/main/timer_switch.c
@@ -1,0 +1,93 @@
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "driver/gpio.h"
+#include "esp_matter.h"
+#include "app_priv.h"
+#include "esp_event.h"
+
+static const char *TAG = "timer_switch";
+
+#define GPIO_OUTPUT_PIN 2
+
+static esp_timer_handle_t on_timer;
+static esp_timer_handle_t off_timer;
+static bool cycle_mode = false;
+static int64_t on_duration_us = 1000000;  // default 1s
+static int64_t off_duration_us = 1000000; // default 1s
+
+static void off_timer_callback(void* arg);
+
+static void on_timer_callback(void* arg)
+{
+    ESP_LOGI(TAG, "ON timer triggered");
+    gpio_set_level(GPIO_OUTPUT_PIN, 1);
+    if (cycle_mode) {
+        esp_timer_start_once(off_timer, on_duration_us);
+    }
+}
+
+static void off_timer_callback(void* arg)
+{
+    ESP_LOGI(TAG, "OFF timer triggered");
+    gpio_set_level(GPIO_OUTPUT_PIN, 0);
+    if (cycle_mode) {
+        esp_timer_start_once(on_timer, off_duration_us);
+    }
+}
+
+static esp_err_t app_event_cb(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    if (event_base == ESP_MATTER_EVENT) {
+        if (event_id == ESP_MATTER_EVENT_STARTED) {
+            ESP_LOGI(TAG, "Matter stack started");
+        }
+    }
+    return ESP_OK;
+}
+
+static void start_continuous(bool on)
+{
+    cycle_mode = false;
+    esp_timer_stop(on_timer);
+    esp_timer_stop(off_timer);
+    gpio_set_level(GPIO_OUTPUT_PIN, on ? 1 : 0);
+}
+
+static void start_cycle(int64_t on_us, int64_t off_us)
+{
+    on_duration_us = on_us;
+    off_duration_us = off_us;
+    cycle_mode = true;
+    gpio_set_level(GPIO_OUTPUT_PIN, 1);
+    esp_timer_start_once(off_timer, on_duration_us);
+}
+
+void app_main(void)
+{
+    gpio_reset_pin(GPIO_OUTPUT_PIN);
+    gpio_set_direction(GPIO_OUTPUT_PIN, GPIO_MODE_OUTPUT);
+
+    const esp_timer_create_args_t on_args = {
+        .callback = &on_timer_callback,
+        .name = "on_timer"};
+    esp_timer_create(&on_args, &on_timer);
+
+    const esp_timer_create_args_t off_args = {
+        .callback = &off_timer_callback,
+        .name = "off_timer"};
+    esp_timer_create(&off_args, &off_timer);
+
+    esp_matter_init();
+    esp_event_handler_register(ESP_MATTER_EVENT, ESP_EVENT_ANY_ID, &app_event_cb, NULL);
+
+    /* Matter node and endpoint initialization */
+    esp_matter_node_t *node = esp_matter_node_create();
+    esp_matter_endpoint_t *endpoint = esp_matter_endpoint_create(node, ESP_MATTER_ENDPOINT_PRIMARY, "TimerSwitch", NULL);
+    esp_matter_switch_add(endpoint);
+
+    esp_matter_start(node, NULL, 0, NULL);  // start matter stack
+
+    // Example usage
+    start_cycle(60000000, 30000000); // 60s ON, 30s OFF
+}
+


### PR DESCRIPTION
## Summary
- add a simple Matter timer switch example
- support continuous or cycle mode for a GPIO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68429798b18883339d5f921a7219a025