### PR TITLE
Add simple unit tests

### DIFF
--- a/main/timer_switch.h
+++ b/main/timer_switch.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+void timer_switch_init(void);
+void start_continuous(bool on);
+void start_cycle(int64_t on_us, int64_t off_us);
+
+#ifdef UNIT_TEST
+extern bool cycle_mode;
+extern int64_t on_duration_us;
+extern int64_t off_duration_us;
+extern esp_timer_handle_t on_timer;
+extern esp_timer_handle_t off_timer;
+#endif

--- a/test/app_priv.h
+++ b/test/app_priv.h
@@ -1,0 +1,1 @@
+#include "esp_stub.h"

--- a/test/driver/gpio.h
+++ b/test/driver/gpio.h
@@ -1,0 +1,2 @@
+#include "../esp_stub.h"
+#define GPIO_MODE_OUTPUT 1

--- a/test/esp_event.h
+++ b/test/esp_event.h
@@ -1,0 +1,1 @@
+#include "esp_stub.h"

--- a/test/esp_log.h
+++ b/test/esp_log.h
@@ -1,0 +1,1 @@
+#include "esp_stub.h"

--- a/test/esp_matter.h
+++ b/test/esp_matter.h
@@ -1,0 +1,1 @@
+#include "esp_stub.h"

--- a/test/esp_stub.c
+++ b/test/esp_stub.c
@@ -1,0 +1,40 @@
+#include "esp_stub.h"
+#include <stdlib.h>
+
+int last_gpio_level = -1;
+esp_timer_handle_t last_timer_started = 0;
+int64_t last_timer_duration = 0;
+int stop_call_count = 0;
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t* args, esp_timer_handle_t* out) {
+    static int next = 1;
+    *out = next++;
+    return ESP_OK;
+}
+
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, int64_t us) {
+    last_timer_started = timer;
+    last_timer_duration = us;
+    return ESP_OK;
+}
+
+esp_err_t esp_timer_stop(esp_timer_handle_t timer) {
+    stop_call_count++;
+    return ESP_OK;
+}
+
+void gpio_set_level(int pin, int level) {
+    last_gpio_level = level;
+}
+
+void gpio_reset_pin(int pin) {}
+
+void gpio_set_direction(int pin, int dir) {}
+
+esp_matter_node_t* esp_matter_node_create(void) { return NULL; }
+esp_matter_endpoint_t* esp_matter_endpoint_create(esp_matter_node_t* n, int id, const char* name, void* data) { return NULL; }
+void esp_matter_switch_add(esp_matter_endpoint_t* e) {}
+void esp_matter_init(void) {}
+void esp_matter_start(esp_matter_node_t* n, void* a, int b, void* c) {}
+
+esp_err_t esp_event_handler_register(esp_event_base_t base, int32_t id, esp_err_t (*cb)(void*, esp_event_base_t, int32_t, void*), void* arg) { return ESP_OK; }

--- a/test/esp_stub.h
+++ b/test/esp_stub.h
@@ -1,0 +1,51 @@
+#ifndef ESP_STUB_H
+#define ESP_STUB_H
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef int esp_err_t;
+#define ESP_OK 0
+
+#define ESP_MATTER_EVENT ((esp_event_base_t)0x01)
+#define ESP_EVENT_ANY_ID 0
+#define ESP_MATTER_EVENT_STARTED 1
+#define ESP_MATTER_ENDPOINT_PRIMARY 1
+
+typedef const void* esp_event_base_t;
+
+typedef int esp_timer_handle_t;
+typedef struct {
+    void (*callback)(void*);
+    const char* name;
+} esp_timer_create_args_t;
+
+esp_err_t esp_timer_create(const esp_timer_create_args_t* args, esp_timer_handle_t* out);
+esp_err_t esp_timer_start_once(esp_timer_handle_t timer, int64_t us);
+esp_err_t esp_timer_stop(esp_timer_handle_t timer);
+
+void gpio_set_level(int pin, int level);
+void gpio_reset_pin(int pin);
+void gpio_set_direction(int pin, int dir);
+
+struct esp_matter_node {int dummy;};
+typedef struct esp_matter_node esp_matter_node_t;
+struct esp_matter_endpoint {int dummy;};
+typedef struct esp_matter_endpoint esp_matter_endpoint_t;
+
+esp_matter_node_t* esp_matter_node_create(void);
+esp_matter_endpoint_t* esp_matter_endpoint_create(esp_matter_node_t*, int, const char*, void*);
+void esp_matter_switch_add(esp_matter_endpoint_t*);
+void esp_matter_init(void);
+void esp_matter_start(esp_matter_node_t*, void*, int, void*);
+
+esp_err_t esp_event_handler_register(esp_event_base_t base, int32_t id, esp_err_t (*cb)(void*, esp_event_base_t, int32_t, void*), void* arg);
+
+#define ESP_LOGI(tag, fmt, ...)
+
+extern int last_gpio_level;
+extern esp_timer_handle_t last_timer_started;
+extern int64_t last_timer_duration;
+extern int stop_call_count;
+
+#endif // ESP_STUB_H

--- a/test/esp_timer.h
+++ b/test/esp_timer.h
@@ -1,0 +1,1 @@
+#include "esp_stub.h"

--- a/test/test_timer_switch.c
+++ b/test/test_timer_switch.c
@@ -1,0 +1,29 @@
+#include "esp_stub.h"
+#include "../main/timer_switch.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    timer_switch_init();
+
+    stop_call_count = 0;
+    last_gpio_level = -1;
+    start_continuous(true);
+    assert(cycle_mode == false);
+    assert(last_gpio_level == 1);
+    assert(stop_call_count == 2);
+
+    stop_call_count = 0;
+    last_gpio_level = -1;
+    last_timer_started = 0;
+    start_cycle(1000, 2000);
+    assert(cycle_mode == true);
+    assert(on_duration_us == 1000);
+    assert(off_duration_us == 2000);
+    assert(last_gpio_level == 1);
+    assert(last_timer_started == off_timer);
+    assert(last_timer_duration == 1000);
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose start functions for unit tests
- add timer_switch_init() helper
- create test stubs for ESP-IDF dependencies
- add a small C test verifying timer behaviour

## Testing
- `gcc -DUNIT_TEST test/test_timer_switch.c test/esp_stub.c main/timer_switch.c -Itest -Itest/driver -Imain -o test_runner && ./test_runner`

------
https://chatgpt.com/codex/tasks/task_e_6842989b0a4c8333b8b7ee3409f6bfa3