### PR TITLE
Rewrite timer switch in C++

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "timer_switch.c"
+idf_component_register(SRCS "timer_switch.cpp"
                        INCLUDE_DIRS ".")

--- a/main/timer_switch.h
+++ b/main/timer_switch.h
@@ -2,9 +2,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void timer_switch_init(void);
 void start_continuous(bool on);
 void start_cycle(int64_t on_us, int64_t off_us);
+
+#ifdef __cplusplus
+}
+#endif
 
 #ifdef UNIT_TEST
 extern bool cycle_mode;

--- a/test/test_timer_switch.cpp
+++ b/test/test_timer_switch.cpp
@@ -1,7 +1,7 @@
 #include "esp_stub.h"
 #include "../main/timer_switch.h"
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 int main(void) {
     timer_switch_init();


### PR DESCRIPTION
## Summary
- convert timer switch implementation to C++
- update component build configuration
- adapt unit tests for C++

## Testing
- `g++ -DUNIT_TEST test/test_timer_switch.cpp test/esp_stub.c main/timer_switch.cpp -o test/test_timer_switch -Itest -Imain`
- `./test/test_timer_switch`


------
https://chatgpt.com/codex/tasks/task_e_6842a37107e48333a2a6c8bd1ea12a96